### PR TITLE
fix candle timestamp boundary issue

### DIFF
--- a/src/lib/chart.js
+++ b/src/lib/chart.js
@@ -214,6 +214,9 @@ export async function loadCandles(_resolution, _start, _end, prepend, productOve
 		// prepend candles to existing set
 		let prepend_set = [];
 		for (const item of json) {
+			// TODO: This is temporary solution to fix duplicate data as the backend includes both start time and end time while returning data
+			const candleTime = correctedTime(item[0]);
+			if (candles.length && candleTime === candles[0].time) continue; // Skip duplicate
 			prepend_set.push({
 				time: correctedTime(item[0]),
 				open: item[1],
@@ -228,6 +231,9 @@ export async function loadCandles(_resolution, _start, _end, prepend, productOve
 	} else {
 		candles = [];
 		for (const item of json) {
+			// TODO: This is temporary solution to fix duplicate data as the backend includes both start time and end time while returning data
+			const candleTime = correctedTime(item[0]);
+			if (candles.length && candleTime === candles[0].time) continue; // Skip duplicate
 			candles.push({
 				time: correctedTime(item[0]),
 				open: item[1],


### PR DESCRIPTION
### Description
Currently the price service rounds up both the start and end timestamps. So, it includes both of them in the response and causes duplicate data on the FE. For now, we decided to fix it on FE side because aggregator needs to request price info with `start==end` which returns no data if we exclude one of the boundaries on the price provider side.