### PR TITLE
Add example stock product (AAPL-USD)

### DIFF
--- a/src/components/modals/Confirmation.svelte
+++ b/src/components/modals/Confirmation.svelte
@@ -47,7 +47,7 @@
 
 	function findExistingPosition() {
 		for (const pos of $positions) {
-			if (pos.currencyLabel == data.currencyLabel && pos.isLong == data.isLong) return pos;
+			if (pos.productId == data.productId && pos.currencyLabel == data.currencyLabel && pos.isLong == data.isLong) return pos;
 		}
 	}
 

--- a/src/lib/products.js
+++ b/src/lib/products.js
@@ -1,3 +1,6 @@
+// IMPORTANT: ETH-USD should be kept in products in any deployment for two main reasons
+// 1. It's default product in autonom and hardcoded in some other parts as a fallback value
+// 2. Autonom supports two different collaterals (weth and usdc). We need to know price of weth in some parts. So, we need to get ETH-USD price data from price service.
 export const PRODUCTS = {
 	'ETH-USD': {
 		hours: '24/7',
@@ -10,7 +13,7 @@ export const PRODUCTS = {
 			usdc: 8000000
 		}
 	},
-	'BTC-USD': {
+	'AAPL-USD': {
 		hours: '24/7',
 		logo: '/logos/BTC.svg',
 		baseSpread: 0.0001,

--- a/src/lib/stream.js
+++ b/src/lib/stream.js
@@ -8,6 +8,8 @@ import { onNewPrice } from './chart'
 
 import { setTitle, shortSymbol, showToast, hideToast } from './utils'
 
+import { PRODUCTS } from './products'
+
 let ws;
 let h;
 let subscribedProducts = {
@@ -105,13 +107,13 @@ export function initWebsocket() {
 	// Poll
 	clearInterval(poller);
 
-	for (const product_id of ['ETH-USD']) {
+	for (const product_id of Object.keys(PRODUCTS)) {
 		getPrice(product_id);
 	}
 
 	// Poll for prices every 5 sec
 	poller = setInterval(() => {
-		for (const product_id of ['ETH-USD']) {
+		for (const product_id of Object.keys(PRODUCTS)) {
 			getPrice(product_id);
 		}
 	}, 5000);


### PR DESCRIPTION
### Description
This PR includes following changes:
1. Added example stock product called AAPL-USD. This is also added into the protocol side in this PR.
2. Fixed combining different products in the same position bug. When opening a new position, it was showing wrong data on the confirmation modal as it tries to combine new position with the already exiting one even though they are not the same products.

### Testing
Run localnet
Run frontend
Try to switch between different products and open/close positions